### PR TITLE
python2 compatibility fixes

### DIFF
--- a/smithplot/smithaxes.py
+++ b/smithplot/smithaxes.py
@@ -1009,7 +1009,7 @@ class SmithAxes(Axes):
                     len_x, len_y = len(xticks) - 1, len(yticks) - 1
 
                     # 2. Step: calculate optimal gridspacing for each quadrant
-                    d_mat = np.ones((len_x, len_y, 2))
+                    d_mat = np.ones((len_x, len_y, 2), dtype=np.int)
 
                     # TODO: optimize spacing algorithm
                     for i in range(len_x):

--- a/smithplot/smithaxes.py
+++ b/smithplot/smithaxes.py
@@ -36,6 +36,8 @@ of all given parameters. This does not work always, especially if the
 parameters are array-like types (e.g. numpy.ndarray).
 '''
 
+from __future__ import division, print_function, unicode_literals
+
 from collections import Iterable
 from numbers import Number
 from types import MethodType, FunctionType
@@ -558,7 +560,7 @@ class SmithAxes(Axes):
     def drag_pan(self, button, key, x, y):
         pass
 
-    def _moebius_z(self, *args, normalize=None):
+    def _moebius_z(self, *args, **kw):
         '''
         Basic transformation. 
         
@@ -581,11 +583,12 @@ class SmithAxes(Axes):
                 Performs w = (z - k) / (z + k) with k = 'axes.scale' 
                 Type: Complex number or numpy.ndarray with dtype=complex
         '''
+        normalize = kw.get('normalize', None)
         normalize = self._normalize if normalize is None else normalize
         norm = 1 if normalize else self._impedance
         return smithhelper.moebius_z(*args, norm=norm)
 
-    def _moebius_inv_z(self, *args, normalize=None):
+    def _moebius_inv_z(self, *args, **kw):
         '''
         Basic inverse transformation. 
         
@@ -608,6 +611,7 @@ class SmithAxes(Axes):
                 Performs w = k * (1 - z) / (1 + z) with k = 'axes.scale' 
                 Type: Complex number or numpy.ndarray with dtype=complex
         '''
+        normalize = kw.get('normalize', None)
         normalize = self._normalize if normalize is None else normalize
         norm = 1 if normalize else self._impedance
         return smithhelper.moebius_inv_z(*args, norm=norm)

--- a/smithplot/smithhelper.py
+++ b/smithplot/smithhelper.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # last edit: 11.04.2018
 
+from __future__ import division,  print_function, unicode_literals
+
 from collections import Iterable
 
 import numpy as np
@@ -38,13 +40,15 @@ def z_to_xy(z):
     return z.real, z.imag
 
 
-def moebius_z(*args, norm):
+def moebius_z(*args, **kw):
     z = xy_to_z(*args)
+    norm = kw['norm']
     return 1 - 2 * norm / (z + norm)
 
 
-def moebius_inv_z(*args, norm):
+def moebius_inv_z(*args, **kw):
     z = xy_to_z(*args)
+    norm = kw['norm']
     return norm * (1 + z) / (1 - z)
 
 


### PR DESCRIPTION
Some python 2.x compatibility fixes:
* initialized keyword(s) not allowed after *args in python2.x, use general **kw instead
* Ohm signs and other are unicode only, use unicode_literals (and others) from future module
