### PR TITLE
Make it compatible with numpy > 1.16

### DIFF
--- a/smithplot/smithaxes.py
+++ b/smithplot/smithaxes.py
@@ -1005,7 +1005,7 @@ class SmithAxes(Axes):
                     len_x, len_y = len(xticks) - 1, len(yticks) - 1
 
                     # 2. Step: calculate optimal gridspacing for each quadrant
-                    d_mat = np.ones((len_x, len_y, 2))
+                    d_mat = np.ones((len_x, len_y, 2), dtype=np.int)
 
                     # TODO: optimize spacing algorithm
                     for i in range(len_x):


### PR DESCRIPTION
In version of numpy higher than 1.16 the third argument of linspace is not be interpreted as integer and would produce and error. 

https://docs.scipy.org/doc/numpy/release.html?highlight=histogram

Then matrix d_mat need to be initialized as a integer type.