### PR TITLE
Fix import: Iterable is in collections.abc

### DIFF
--- a/smithplot/smithaxes.py
+++ b/smithplot/smithaxes.py
@@ -36,7 +36,10 @@ of all given parameters. This does not work always, especially if the
 parameters are array-like types (e.g. numpy.ndarray).
 '''
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from numbers import Number
 from types import MethodType, FunctionType
 

--- a/smithplot/smithhelper.py
+++ b/smithplot/smithhelper.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # last edit: 11.04.2018
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
.. in newer versions of python3. Fixes #34.