### PR TITLE
Fix for newer matplotlib no type np.complex

### DIFF
--- a/smithplot/smithaxes.py
+++ b/smithplot/smithaxes.py
@@ -728,7 +728,7 @@ class SmithAxes(Axes):
                     pass
 
             # if (converted) arg is an ndarray of complex type, split it
-            if isinstance(arg, np.ndarray) and arg.dtype in [np.complex, np.complex128]:
+            if isinstance(arg, np.ndarray) and arg.dtype in [complex, np.complex128]:
                 new_args += z_to_xy(arg)
             else:
                 new_args += (arg,)


### PR DESCRIPTION
The type 'np.complex' has long been deprecated in matplotlib. Solution is to use the python builtin type 'complex'.